### PR TITLE
Ensure default configuration file is created

### DIFF
--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::PathBuf;
+
+/// Name of the default configuration file created next to the executable.
+const DEFAULT_CONFIG_NAME: &str = "sp2any.json";
+
+/// Ensure that the configuration file exists.
+///
+/// If the file is missing, it will be created with placeholder content so
+/// that users can fill in the required credentials.  The path to the
+/// configuration file is returned for informational purposes.
+pub fn ensure_config_file() -> Result<PathBuf> {
+    let path = PathBuf::from(DEFAULT_CONFIG_NAME);
+
+    if !path.exists() {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let mut file = File::create(&path)?;
+        let default_content = r#"{
+  "simply_plural_token": "",
+  "discord_status_message_token": "",
+  "vrchat_username": "",
+  "vrchat_password": ""
+}
+"#;
+        file.write_all(default_content.as_bytes())?;
+    }
+
+    Ok(path)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 
 use clap::Parser;
 
+mod config_file;
 mod database;
 mod http;
 mod platforms;
@@ -16,6 +17,10 @@ mod users;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Ensure that the local configuration file exists before continuing so
+    // the executable can be run without manually creating it beforehand.
+    let _ = config_file::ensure_config_file()?;
+
     let cli_args = setup::CliArgs::parse();
 
     let app_setup = setup::application_setup(&cli_args).await?;


### PR DESCRIPTION
## Summary
- Create helper to generate `sp2any.json` with placeholder fields
- Invoke helper in main so the executable always prepares the config file

## Testing
- `./release/lint.sh` *(fails: process interrupted while compiling)*

------
https://chatgpt.com/codex/tasks/task_e_68bca09dd0d483308f9b0b985f56bb30